### PR TITLE
Restore default timezone in Calendar Extension

### DIFF
--- a/src/Aeon/Twig/CalendarExtension.php
+++ b/src/Aeon/Twig/CalendarExtension.php
@@ -22,15 +22,22 @@ final class CalendarExtension extends AbstractExtension
 {
     private Calendar $calendar;
 
+    private TimeZone $defaultTimeZone;
+
     private string $defaultDateTimeFormat;
 
     private string $defaultDayFormat;
 
     private string $defaultTimeFormat;
 
-    public function __construct(Calendar $calendar, string $defaultDateTimeFormat = 'Y-m-d H:i:s', string $defaultDayFormat = 'Y-m-d', string $defaultTimeFormat = 'H:i:s')
+    public function __construct(Calendar $calendar, string $defaultTimeZone = 'UTC', string $defaultDateTimeFormat = 'Y-m-d H:i:s', string $defaultDayFormat = 'Y-m-d', string $defaultTimeFormat = 'H:i:s')
     {
+        if (!TimeZone::isValid($defaultTimeZone)) {
+            throw new InvalidArgumentException($defaultTimeZone . ' is not valid timezone name.');
+        }
+
         $this->calendar = $calendar;
+        $this->defaultTimeZone = new TimeZone($defaultTimeZone);
         $this->defaultDateTimeFormat = $defaultDateTimeFormat;
         $this->defaultDayFormat = $defaultDayFormat;
         $this->defaultTimeFormat = $defaultTimeFormat;
@@ -85,7 +92,7 @@ final class CalendarExtension extends AbstractExtension
             return $dateTime->toTimeZone($tz)->format($fmt);
         }
 
-        return $dateTime->toTimeZone($this->calendar->timeZone())->format($fmt);
+        return $dateTime->toTimeZone($this->defaultTimeZone)->format($fmt);
     }
 
     public function aeon_time_format(Time $time, string $format = null) : string

--- a/tests/Aeon/Twig/Tests/Integration/CalendarExtensionTest.php
+++ b/tests/Aeon/Twig/Tests/Integration/CalendarExtensionTest.php
@@ -34,7 +34,7 @@ final class CalendarExtensionTest extends TestCase
                 ]
             )
         );
-        $twig->addExtension(new CalendarExtension($this->calendarStub, 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
+        $twig->addExtension(new CalendarExtension($this->calendarStub, 'UTC', 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
 
         $this->assertStringEqualsFile(
             __DIR__ . '/Fixtures/filters/aeon_datetime_format.txt',
@@ -51,7 +51,7 @@ final class CalendarExtensionTest extends TestCase
                 ]
             )
         );
-        $twig->addExtension(new CalendarExtension($this->calendarStub, 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
+        $twig->addExtension(new CalendarExtension($this->calendarStub, 'UTC', 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
 
         $this->assertStringEqualsFile(
             __DIR__ . '/Fixtures/filters/aeon_day_format.txt',
@@ -68,7 +68,7 @@ final class CalendarExtensionTest extends TestCase
                 ]
             )
         );
-        $twig->addExtension(new CalendarExtension($this->calendarStub, 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
+        $twig->addExtension(new CalendarExtension($this->calendarStub, 'UTC', 'Y-m-d H:i:sO', 'Y-m-d', 'H:i:s'));
 
         $this->assertStringEqualsFile(
             __DIR__ . '/Fixtures/filters/aeon_time_format.txt',
@@ -119,7 +119,7 @@ final class CalendarExtensionTest extends TestCase
                 ]
             )
         );
-        $twig->addExtension(new CalendarExtension($this->calendarStub, 'Y-m-d H:i:sO', 'Y-m-d'));
+        $twig->addExtension(new CalendarExtension($this->calendarStub, 'UTC', 'Y-m-d H:i:sO', 'Y-m-d'));
 
         $this->assertStringEqualsFile(
             __DIR__ . '/Fixtures/functions/aeon_now.txt',

--- a/tests/Aeon/Twig/Tests/Unit/CalendarExtensionTest.php
+++ b/tests/Aeon/Twig/Tests/Unit/CalendarExtensionTest.php
@@ -16,6 +16,14 @@ use PHPUnit\Framework\TestCase;
 
 final class CalendarExtensionTest extends TestCase
 {
+    public function test_create_with_invalid_timezone() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not_timezone is not valid timezone name.');
+
+        new CalendarExtension($calendar = new GregorianCalendarStub(), 'not_timezone');
+    }
+
     public function test_aeon_now() : void
     {
         $extension = new CalendarExtension($calendar = new GregorianCalendarStub());
@@ -29,7 +37,8 @@ final class CalendarExtensionTest extends TestCase
     public function test_aeon_datetime_format_takes_timezone_from_calendar_instance_when_not_provided() : void
     {
         $extension = new CalendarExtension(
-            $calendar = new GregorianCalendarStub(new \DateTimeImmutable('2020-01-01 Europe/Warsaw'))
+            $calendar = new GregorianCalendarStub(new \DateTimeImmutable('2020-01-01 UTC')),
+            'Europe/Warsaw'
         );
 
         $this->assertEquals(


### PR DESCRIPTION
Previously I thought it would be a good idea to reduce the number of arguments in the CalendarExtension constructor and take the timezone from the calendar instance. 
However, I didn't predict that because of that one system that would like to use in the backend UTC timezone and a different one in the UI would need to use 2 different instances of the calendar, which is maybe not that bad but also gives no benefits. 